### PR TITLE
メッセージ送信機能実装No.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/_chat-main.html.haml
+++ b/app/views/messages/_chat-main.html.haml
@@ -1,29 +1,15 @@
 .chat-main
   .main-header
     .main-header__left-box
-      %h2.main-header__left-box__current-group ためし１
+      %h2.main-header__left-box__current-group
+        = @group.name
       %ul.main-header__left-box__member-list Member：
-      %li.main-header__left-box__member-list__member わかめ
-      %li.main-header__left-box__member-list__member かに
-      %li.main-header__left-box__member-list__member おおみや
-      %li.main-header__left-box__member-list__member まめ
+      %li.main-header__left-box__member-list__member
+        - @group.group_users.each do |group_user|
+          = group_user.user.name
     %input.main-header__edit-btn{type: "button", value: "Edit"}
   .messages
-    .message
-      .message__upper-info
-        %p.message__upper-info__talker 自分
-        %p.message__upper-info__date 2019/09/06(Fri) 15:57:22
-      %p.message__text テスト１
-    .message
-      .message__upper-info
-        %p.message__upper-info__talker 自分
-        %p.message__upper-info__date 2019/09/06(Fri) 15:57:22
-      %p.message__text テスト２
-    .message
-      .message__upper-info
-        %p.message__upper-info__talker 自分
-        %p.message__upper-info__date 2019/09/06(Fri) 15:57:22
-      %p.message__text テスト３
+    = render partial: 'message', collection: @messages
   
   .form.new_message
     = form_for [@group, @message] do |f|

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .message__upper-info
+    %p.message__upper-info__talker
+      = message.user.name
+    %p.message__upper-info__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  %p.message__text
+    - if message.body.present?
+      %p.lower-message__content
+        = message.body
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side-bar.html.haml
+++ b/app/views/messages/_side-bar.html.haml
@@ -16,4 +16,4 @@
           .group__group-name
             = group.name
           .group__latest-message
-            メッセージはまだありません。
+            = group.show_last_message


### PR DESCRIPTION
# What
・投稿したメッセージがビューに表示されるように修正
・サイドバーのグループ部分に最新のメッセージが表示されるように修正
・メインのヘッダー部分にグループ名とそのメンバー全員が表示されるように修正

# Why
投稿したメッセージのビューへの表示は、本アプリケーション実装をする上で必須であるため。
また他の２点はユーザーの利便性を考えた上で必要となる機能であるため。