### PR TITLE
メッセージ送信機能の非同期通信実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,4 @@ gem "font-awesome-rails"
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -251,6 +253,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  jquery-ui-rails
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,46 @@
+$(function(){
+  function buildHTML(message){
+    var image_url = message.image?  `<img class="lower-message__image" src="${message.image}">`: '' ;
+    var html = `<div class="message">
+                  <div class="message__upper-info">
+                    <p class="message__upper-info__talker">
+                    ${message.name}
+                    </p>
+                    <p class="message__upper-info__date">
+                    ${message.created_at}
+                    </p>
+                  </div>
+                  <p class="message__text">
+                  </p>
+                  <p class="lower-message__content">
+                  ${message.body}
+                  </p>
+                  ${image_url}
+                  <p></p>
+                </div>`
+    return html;
+  }
+  $('.new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html)
+      $('.input-box__text').val('')
+      $('.input-box__image__file').val('')
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+})

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,8 +35,7 @@ $(function(){
     .done(function(data){
       var html = buildHTML(data);
       $('.messages').append(html)
-      $('.input-box__text').val('')
-      $('.input-box__image__file').val('')
+      $('.new_message')[0].reset();
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function(){

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,7 +3,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [200, 200]
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog

--- a/app/views/messages/_chat-main.html.haml
+++ b/app/views/messages/_chat-main.html.haml
@@ -11,7 +11,7 @@
   .messages
     = render partial: 'message', collection: @messages
   
-  .form.new_message
+  .form
     = form_for [@group, @message] do |f|
       .form-box
         .input-box

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.body  @message.body
+json.image  @message.image.url
+json.name  @message.user.name
+json.created_at  @message.created_at.to_s

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
+    config.action_view.automatically_disable_submit_tag = false
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:default] = '%Y/%m/%d %H:%M'


### PR DESCRIPTION
# What
メッセージ送信機能を非同期通信で行うことができるよう実装した。
respond_toを用いてコントローラーのアクションの中でHTMLとJSONといったフォーマット毎に条件分岐させた。また、jbuilderを使用して、入力データをJSON形式で返すようにした。

- テキストのみ送信と空送信で出るアラート
https://gyazo.com/a6b49629676f4ad0ef237dc9bc1df292

- 画像のみとテキストのみの連続送信
https://gyazo.com/66efd56eec805d1ef2da1b381171ba52

- 画像とテキストの両方を入れて送信
https://gyazo.com/66efd56eec805d1ef2da1b381171ba52

# Why
リロードをさせないことで、通信時のデータ通信量を削減させるため。