### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function(){
   function buildHTML(message){
     var image_url = message.image?  `<img class="lower-message__image" src="${message.image}">`: '' ;
-    var html = `<div class="message">
+    var html = `<div class="message" data-id="${message.id}">
                   <div class="message__upper-info">
                     <p class="message__upper-info__talker">
                     ${message.name}
@@ -20,6 +20,7 @@ $(function(){
                 </div>`
     return html;
   }
+  
   $('.new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -42,4 +43,36 @@ $(function(){
       alert('error');
     })
   })
-})
+
+  var reloadMessages = function() {
+    var page_url = location.href;
+    if (page_url.match(/groups\/\d\/messages/)) {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      var last_message_id = $('.message:last').data('id');
+      
+      $.ajax({
+        //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+        url: './api/messages',
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        console.log(messages)
+        var insertHTML = '';
+        messages.forEach(function(message){
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+        });
+        console.log('success');
+      })
+      .fail(function() {
+        console.log('error');
+      });
+    };
+  };
+  setInterval(reloadMessages, 5000);
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -60,17 +60,15 @@ $(function(){
         data: {id: last_message_id}
       })
       .done(function(messages) {
-        console.log(messages)
         var insertHTML = '';
         messages.forEach(function(message){
           insertHTML = buildHTML(message);
           $('.messages').append(insertHTML);
           $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight}, 'fast');
         });
-        console.log('success');
       })
       .fail(function() {
-        console.log('error');
+        alert('error');
       });
     };
   };

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body message.body
+  json.image message.image.url
+  json.created_at message.created_at.to_s
+  json.name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: message.id}}
   .message__upper-info
     %p.message__upper-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.body  @message.body
 json.image  @message.image.url
 json.name  @message.user.name
 json.created_at  @message.created_at.to_s
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
チャット画面の自動更新機能を実装した。

- テキストの自動更新画面
https://gyazo.com/0562810176950f3635c5ab59a3a2e660
- 画像の自動更新画面
https://gyazo.com/6b4c5d61d6f7c5d96fee77988fad0749

# Why
別のユーザーが別の画面から投稿したメッセージがすぐに表示されないと、ユーザーの利便性を損なうため。